### PR TITLE
elk-#47 Introduce maybe uninit for publisher and sample mut

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,34 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: yes
+  require_base: yes
+  require_head: yes
+
+coverage:
+  range: 70..100
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 2% # allow coverage to drop maximum by a defined value
+        flags:
+          - unittest
+    patch:
+      default:
+        target: auto
+        threshold: 2% # allow coverage to drop maximum by a defined value
+        flags:
+          - unittest
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: yes
+      macro: yes

--- a/elkodon/src/compiletests.rs
+++ b/elkodon/src/compiletests.rs
@@ -1,0 +1,21 @@
+/// ```compile_fail
+/// use elkodon::prelude::*;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let service_name = ServiceName::new(b"My/Funk/ServiceName").unwrap();
+/// #
+/// # let service = zero_copy::Service::new(&service_name)
+/// #     .publish_subscribe()
+/// #     .open_or_create::<u64>()?;
+/// #
+/// # let publisher = service.publisher().create()?;
+///
+/// let mut sample = publisher.loan()?;
+/// sample.payload_mut().write(1234);
+///
+/// publisher.send(sample)?; // should fail to compile
+///
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(doctest)]
+fn sending_uninitialized_sample_fails_to_compile() {}

--- a/elkodon/src/lib.rs
+++ b/elkodon/src/lib.rs
@@ -256,6 +256,7 @@
 pub mod config;
 
 pub(crate) mod message;
+pub(crate) mod raw_sample;
 
 /// The ports or communication endpoints of elkodon
 pub mod port;

--- a/elkodon/src/lib.rs
+++ b/elkodon/src/lib.rs
@@ -88,7 +88,8 @@
 //!
 //! while !SignalHandler::termination_requested() {
 //!     let mut sample = publisher.loan()?;
-//!     unsafe { sample.as_mut_ptr().write(1234) };
+//!     sample.payload_mut().write(1234);
+//!     let sample = unsafe { sample.assume_init() };
 //!     publisher.send(sample)?;
 //!
 //!     std::thread::sleep(std::time::Duration::from_secs(1));

--- a/elkodon/src/lib.rs
+++ b/elkodon/src/lib.rs
@@ -253,14 +253,18 @@
 //! For in-depth details and examples, please visit the
 //! [GitHub config folder](https://github.com/elkodon/elkodon/tree/main/config).
 
+#[cfg(doctest)]
+mod compiletests;
+
 /// Handles elkodons global configuration
 pub mod config;
 
 pub(crate) mod message;
-pub(crate) mod raw_sample;
 
 /// The ports or communication endpoints of elkodon
 pub mod port;
+
+pub(crate) mod raw_sample;
 
 /// The payload that is received by a [`crate::port::subscriber::Subscriber`].
 pub mod sample;

--- a/elkodon/src/message.rs
+++ b/elkodon/src/message.rs
@@ -1,5 +1,16 @@
+use core::fmt;
+
 #[repr(C)]
 pub(crate) struct Message<Header, Data> {
     pub(crate) header: Header,
     pub(crate) data: Data,
+}
+
+impl<Header: fmt::Debug, Data: fmt::Debug> fmt::Debug for Message<Header, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Message<Header, Data>")
+            .field("header", &self.header)
+            .field("data", &self.data)
+            .finish()
+    }
 }

--- a/elkodon/src/port/publisher.rs
+++ b/elkodon/src/port/publisher.rs
@@ -19,9 +19,8 @@
 //!
 //! // loan some memory and send it
 //! let mut sample = publisher.loan()?;
-//! unsafe {
-//!     sample.as_mut_ptr().write(1337);
-//! }
+//! sample.payload_mut().write(1337);
+//! let sample = unsafe { sample.assume_init() };
 //! publisher.send(sample)?;
 //!
 //! // send a copy of the value
@@ -34,12 +33,13 @@
 use std::cell::UnsafeCell;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::{alloc::Layout, marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
+use std::{alloc::Layout, marker::PhantomData, mem::MaybeUninit};
 
 use super::port_identifiers::{UniquePublisherId, UniqueSubscriberId};
 use crate::message::Message;
 use crate::port::details::subscriber_connections::*;
 use crate::port::{DegrationAction, DegrationCallback};
+use crate::raw_sample::RawSampleMut;
 use crate::service;
 use crate::service::header::publish_subscribe::Header;
 use crate::service::port_factory::publisher::{LocalPublisherConfig, UnableToDeliverStrategy};
@@ -505,7 +505,7 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Debug>
         let mut sample = fail!(from self, when self.loan(),
                                     "{} since the loan of a sample failed.", msg);
 
-        unsafe { sample.as_mut_ptr().write(value) };
+        sample.payload_mut().write(value);
         Ok(
             fail!(from self, when self.send_impl(sample.offset_to_chunk().value()),
             "{} since the underlying send operation failed.", msg),
@@ -516,7 +516,10 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Debug>
     /// On failure it returns [`LoanError`] describing the failure.
     pub fn loan<'publisher>(
         &'publisher self,
-    ) -> Result<SampleMut<'a, 'publisher, 'config, Service, Header, MessageType>, LoanError> {
+    ) -> Result<
+        SampleMut<'a, 'publisher, 'config, Service, Header, MaybeUninit<MessageType>>,
+        LoanError,
+    > {
         self.retrieve_returned_samples();
         let msg = "Unable to loan Sample";
 
@@ -539,17 +542,20 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Debug>
                                 "{} since the allocated sample is already in use! This should never happen!", msg);
                 }
 
-                let mut chunk_ptr;
-                unsafe {
-                    chunk_ptr = NonNull::new_unchecked(
-                        chunk.data_ptr as *mut MaybeUninit<Message<Header, MessageType>>,
-                    );
-                    let header_ptr =
-                        std::ptr::addr_of_mut!((*chunk_ptr.as_mut().as_mut_ptr()).header);
-                    header_ptr.write(Header::new(self.port_id))
-                }
+                let message =
+                    chunk.data_ptr as *mut MaybeUninit<Message<Header, MaybeUninit<MessageType>>>;
 
-                Ok(SampleMut::new(self, chunk_ptr, chunk.offset))
+                let sample = unsafe {
+                    (*message).write(Message {
+                        header: Header::new(self.port_id),
+                        data: MaybeUninit::uninit(),
+                    });
+                    RawSampleMut::new_unchecked(
+                        message as *mut Message<Header, MaybeUninit<MessageType>>,
+                    )
+                };
+
+                Ok(SampleMut::new(self, sample, chunk.offset))
             }
             Err(ShmAllocationError::AllocationError(AllocationError::OutOfMemory)) => {
                 fail!(from self, with LoanError::OutOfMemory,

--- a/elkodon/src/port/publisher.rs
+++ b/elkodon/src/port/publisher.rs
@@ -485,8 +485,12 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Debug>
 
     /// Send a previously loaned [`Publisher::loan()`] [`SampleMut`] to all connected
     /// [`crate::port::subscriber::Subscriber`]s of the service.
-    /// On success it returns the number of [`crate::port::subscriber::Subscriber`]s that received
-    /// the data, otherwise a [`ZeroCopyCreationError`] describing the failure.
+    ///
+    /// The payload of the [`SampleMut`] must be initialized before it can be sent. Have a look
+    /// at [`SampleMut::write_payload()`] and [`SampleMut::assume_init()`] for more details.
+    ///
+    /// On success the number of [`crate::port::subscriber::Subscriber`]s that received
+    /// the data is returned, otherwise a [`ZeroCopyCreationError`] describing the failure.
     pub fn send<'publisher>(
         &'publisher self,
         sample: SampleMut<'a, 'publisher, 'config, Service, Header, MessageType>,

--- a/elkodon/src/raw_sample.rs
+++ b/elkodon/src/raw_sample.rs
@@ -1,0 +1,193 @@
+use crate::message::Message;
+
+use core::fmt;
+
+/// A `*const Message<Header, Data>` non-zero sample pointer to the message.
+#[repr(transparent)]
+pub(crate) struct RawSample<Header, Data> {
+    message: *const Message<Header, Data>,
+}
+
+impl<Header, Data> RawSample<Header, Data> {
+    /// Creates a new `RawSample`.
+    ///
+    /// # Safety
+    ///
+    /// `message` must be non-null.
+    #[inline]
+    pub(crate) unsafe fn new_unchecked(message: *const Message<Header, Data>) -> Self {
+        debug_assert!(
+            !message.is_null(),
+            "RawSample::new_unchecked requires that the message pointer is non-null"
+        );
+        Self { message }
+    }
+
+    /// Creates a new `RawSample`.
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn new(message: *const Message<Header, Data>) -> Option<Self> {
+        if !message.is_null() {
+            // SAFETY: `message` pointer is checked to be non-null
+            Some(unsafe { Self::new_unchecked(message) })
+        } else {
+            None
+        }
+    }
+
+    /// Acquires the underlying message as `*const` pointer.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_ptr(self) -> *const Message<Header, Data> {
+        self.message
+    }
+
+    /// Acquires the underlying message as reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_ref(&self) -> &Message<Header, Data> {
+        // SAFETY: `self.as_ptr()` returns a non-null ptr and `Data` is either the actual message type or wrapped by a `MaybeUninit` which makes a reference to `Message::data` safe
+        unsafe { &(*self.as_ptr()) }
+    }
+
+    /// Acquires the underlying header as reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_header_ref(&self) -> &Header {
+        &self.as_ref().header
+    }
+
+    /// Acquires the underlying data as reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_data_ref(&self) -> &Data {
+        &self.as_ref().data
+    }
+}
+
+impl<Header, Data> Clone for RawSample<Header, Data> {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Header, Data> Copy for RawSample<Header, Data> {}
+
+impl<Header: fmt::Debug, Data: fmt::Debug> fmt::Debug for RawSample<Header, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.message, f)
+    }
+}
+
+impl<Header, Data> fmt::Pointer for RawSample<Header, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.message, f)
+    }
+}
+
+/// A `*mut Message<Header, Data>` non-zero sample pointer to the message.
+#[repr(transparent)]
+pub(crate) struct RawSampleMut<Header, Data> {
+    message: *mut Message<Header, Data>,
+}
+
+impl<Header, Data> RawSampleMut<Header, Data> {
+    /// Creates a new `RawSampleMut`.
+    ///
+    /// # Safety
+    ///
+    /// `message` must be non-null.
+    #[inline]
+    pub(crate) unsafe fn new_unchecked(message: *mut Message<Header, Data>) -> Self {
+        debug_assert!(
+            !message.is_null(),
+            "RawSampleMut::new_unchecked requires that the message pointer is non-null"
+        );
+        Self { message }
+    }
+
+    /// Creates a new `RawSampleMut`.
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn new(message: *mut Message<Header, Data>) -> Option<Self> {
+        if !message.is_null() {
+            // SAFETY: `message` pointer is checked to be non-null
+            Some(unsafe { Self::new_unchecked(message) })
+        } else {
+            None
+        }
+    }
+
+    /// Acquires the underlying message as `*const` pointer.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_ptr(self) -> *const Message<Header, Data> {
+        self.message
+    }
+
+    /// Acquires the underlying message as `*mut` pointer.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_mut_ptr(self) -> *mut Message<Header, Data> {
+        self.message
+    }
+
+    /// Acquires the underlying message as reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_ref(&self) -> &Message<Header, Data> {
+        // SAFETY: `self.as_ptr()` returns a non-null ptr and `Data` is either the actual message type or wrapped by a `MaybeUninit` which makes a reference to `Message::data` safe
+        unsafe { &(*self.as_ptr()) }
+    }
+
+    /// Acquires the underlying message as mut reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_mut(&mut self) -> &mut Message<Header, Data> {
+        // SAFETY: `self.as_ptr()` returns a non-null ptr and `Data` is either the actual message type or wrapped by a `MaybeUninit` which makes a reference to `Message::data` safe
+        unsafe { &mut (*self.as_mut_ptr()) }
+    }
+
+    /// Acquires the underlying header as reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_header_ref(&self) -> &Header {
+        &self.as_ref().header
+    }
+
+    /// Acquires the underlying data as reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_data_ref(&self) -> &Data {
+        &self.as_ref().data
+    }
+
+    /// Acquires the underlying data as mut reference.
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn as_data_mut(&mut self) -> &mut Data {
+        &mut self.as_mut().data
+    }
+}
+
+impl<Header, Data> Clone for RawSampleMut<Header, Data> {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Header, Data> Copy for RawSampleMut<Header, Data> {}
+
+impl<Header: fmt::Debug, Data: fmt::Debug> fmt::Debug for RawSampleMut<Header, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.as_ptr(), f)
+    }
+}
+
+impl<Header, Data> fmt::Pointer for RawSampleMut<Header, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.as_ptr(), f)
+    }
+}

--- a/elkodon/src/sample_mut.rs
+++ b/elkodon/src/sample_mut.rs
@@ -84,6 +84,13 @@ impl<
         }
     }
 
+    /// Writes the payload to the sample and labels the sample as initialized
+    pub fn write_payload(mut self, value: MessageType) -> SampleMut<'a, 'publisher, 'config, Service, Header, MessageType> {
+        self.payload_mut().write(value);
+        // SAFETY: this is safe since the payload was initialized on the line above
+        unsafe { self.assume_init() }
+    }
+
     /// Extracts the value of the `MaybeUninit<MessageType>` container and labels the sample as initialized
     ///
     /// # Safety

--- a/elkodon/src/sample_mut.rs
+++ b/elkodon/src/sample_mut.rs
@@ -74,7 +74,7 @@ impl<
     ) -> Self {
         publisher.loan_counter.fetch_add(1, Ordering::Relaxed);
 
-        // SAFETY: the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+        // SAFETY: the transmute is not nice but safe since MaybeUninit is #[repr(transparent)} to the inner type
         let publisher = unsafe { std::mem::transmute(publisher) };
 
         Self {
@@ -93,7 +93,7 @@ impl<
     pub unsafe fn assume_init(
         self,
     ) -> SampleMut<'a, 'publisher, 'config, Service, Header, MessageType> {
-        // the transmute is not nice but safe since MaybeUninit has the same layout as the inner type
+        // the transmute is not nice but safe since MaybeUninit is #[repr(transparent)] to the inner type
         std::mem::transmute(self)
     }
 }

--- a/elkodon/tests/publisher_tests.rs
+++ b/elkodon/tests/publisher_tests.rs
@@ -40,9 +40,10 @@ mod publisher {
         let mut sample2 = sut.loan().unwrap();
         let mut sample3 = sut.loan().unwrap();
 
-        unsafe { *sample1.as_mut_ptr() = 1 };
-        unsafe { *sample2.as_mut_ptr() = 2 };
-        unsafe { *sample3.as_mut_ptr() = 3 };
+        sample1.payload_mut().write(1);
+        sample2.payload_mut().write(2);
+        sample3.payload_mut().write(3);
+        let sample3 = unsafe { sample3.assume_init() };
 
         let subscriber = service.subscriber().create().unwrap();
 
@@ -88,7 +89,9 @@ mod publisher {
         let sut = service.publisher().max_loaned_samples(2).create().unwrap();
 
         let _sample1 = sut.loan().unwrap();
-        let sample2 = sut.loan().unwrap();
+        let mut sample2 = sut.loan().unwrap();
+        sample2.payload_mut().write(2);
+        let sample2 = unsafe { sample2.assume_init() };
 
         assert_that!(sut.send(sample2), is_ok);
 

--- a/examples/examples/publish_subscribe/publisher.rs
+++ b/examples/examples/publish_subscribe/publisher.rs
@@ -14,17 +14,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut counter: u64 = 0;
 
     while !SignalHandler::termination_requested() {
+        counter += 1;
+
         let mut sample = publisher.loan()?;
-        unsafe {
-            sample.as_mut_ptr().write(TransmissionData {
-                x: counter as i32,
-                y: counter as i32 * 3,
-                funky: counter as f64 * 812.12,
-            });
-        }
+
+        sample.payload_mut().write(TransmissionData {
+            x: counter as i32,
+            y: counter as i32 * 3,
+            funky: counter as f64 * 812.12,
+        });
+
+        let sample = unsafe { sample.assume_init() };
         publisher.send(sample)?;
 
-        counter += 1;
         println!("Send sample {} ...", counter);
 
         std::thread::sleep(std::time::Duration::from_secs(1));


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR introduces a `RawSample`/`RawSampleMut` as a drop in replacement for `NonNull` with additional methods to reduce the unsafe code. Additionally, `MaybeUninit` is used to prevent publishing uninitialized samples.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked
1. [x] Every source code file has the SPDX header `SPDX-License-Identifier: $(LICENSE_CODE)`
1. [x] Branch follows the naming format (`elk-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/larry-robotics/elkodon/blob/main/doc/release-notes/elkodon-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue.

Relates to #47
