### PR TITLE
elk-#47 Distinguish between 'loan' and 'loan_uninit' for 'Publisher'

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let publisher = service.publisher().create()?;
 
     while !SignalHandler::termination_requested() {
-        let mut sample = publisher.loan_uninit()?;
-        sample.payload_mut().write(1234);
-        let sample = unsafe {
-            sample.assume_init()
-        }
+        let sample = publisher.loan_uninit()?;
+        let sample = sample.write_payload(1234);
         publisher.send(sample)?;
 
         std::thread::sleep(std::time::Duration::from_secs(1));

--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let publisher = service.publisher().create()?;
 
     while !SignalHandler::termination_requested() {
-        let mut sample = publisher.loan()?;
-        unsafe {
-            sample.as_mut_ptr().write(1234);
+        let mut sample = publisher.loan_uninit()?;
+        sample.payload_mut().write(1234);
+        let sample = unsafe {
+            sample.assume_init()
         }
         publisher.send(sample)?;
 

--- a/elkodon/src/compiletests.rs
+++ b/elkodon/src/compiletests.rs
@@ -12,7 +12,7 @@
 /// let mut sample = publisher.loan_uninit()?;
 /// sample.payload_mut().write(1234);
 ///
-/// publisher.send(sample)?; // should fail to compile
+/// publisher.send(sample)?; // should fail to compile since sample contains a 'MaybeUninit<T>' instead of a 'T'
 ///
 /// Ok(())
 /// }
@@ -34,7 +34,7 @@ fn sending_uninitialized_sample_fails_to_compile() {}
 ///
 /// let publisher = service.publisher().create()?;
 ///
-/// let sample = publisher.loan()?; // should fail to compile
+/// let sample = publisher.loan()?; // should fail to compile since 'Wrapper' does not implement 'Default'
 ///
 /// Ok(())
 /// }

--- a/elkodon/src/compiletests.rs
+++ b/elkodon/src/compiletests.rs
@@ -1,21 +1,43 @@
 /// ```compile_fail
 /// use elkodon::prelude::*;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # let service_name = ServiceName::new(b"My/Funk/ServiceName").unwrap();
-/// #
-/// # let service = zero_copy::Service::new(&service_name)
-/// #     .publish_subscribe()
-/// #     .open_or_create::<u64>()?;
-/// #
-/// # let publisher = service.publisher().create()?;
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let service_name = ServiceName::new(b"My/Funk/ServiceName").unwrap();
+///
+/// let service = zero_copy::Service::new(&service_name)
+///     .publish_subscribe()
+///     .open_or_create::<u64>()?;
+///
+/// let publisher = service.publisher().create()?;
 ///
 /// let mut sample = publisher.loan_uninit()?;
 /// sample.payload_mut().write(1234);
 ///
 /// publisher.send(sample)?; // should fail to compile
 ///
-/// # Ok(())
-/// # }
+/// Ok(())
+/// }
 /// ```
 #[cfg(doctest)]
 fn sending_uninitialized_sample_fails_to_compile() {}
+
+/// ```compile_fail
+/// use elkodon::prelude::*;
+///
+/// struct Wrapper(u64);
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let service_name = ServiceName::new(b"My/Funk/ServiceName").unwrap();
+///
+/// let service = zero_copy::Service::new(&service_name)
+///     .publish_subscribe()
+///     .open_or_create::<Wrapper>()?;
+///
+/// let publisher = service.publisher().create()?;
+///
+/// let sample = publisher.loan()?; // should fail to compile
+///
+/// Ok(())
+/// }
+/// ```
+#[cfg(doctest)]
+fn loan_with_type_not_implementing_default_fails_to_compile() {}

--- a/elkodon/src/compiletests.rs
+++ b/elkodon/src/compiletests.rs
@@ -9,7 +9,7 @@
 /// #
 /// # let publisher = service.publisher().create()?;
 ///
-/// let mut sample = publisher.loan()?;
+/// let mut sample = publisher.loan_uninit()?;
 /// sample.payload_mut().write(1234);
 ///
 /// publisher.send(sample)?; // should fail to compile

--- a/elkodon/src/lib.rs
+++ b/elkodon/src/lib.rs
@@ -87,7 +87,7 @@
 //! let publisher = service.publisher().create()?;
 //!
 //! while !SignalHandler::termination_requested() {
-//!     let mut sample = publisher.loan()?;
+//!     let mut sample = publisher.loan_uninit()?;
 //!     sample.payload_mut().write(1234);
 //!     let sample = unsafe { sample.assume_init() };
 //!     publisher.send(sample)?;

--- a/elkodon/src/lib.rs
+++ b/elkodon/src/lib.rs
@@ -87,9 +87,8 @@
 //! let publisher = service.publisher().create()?;
 //!
 //! while !SignalHandler::termination_requested() {
-//!     let mut sample = publisher.loan_uninit()?;
-//!     sample.payload_mut().write(1234);
-//!     let sample = unsafe { sample.assume_init() };
+//!     let sample = publisher.loan_uninit()?;
+//!     let sample = sample.write_payload(1234);
 //!     publisher.send(sample)?;
 //!
 //!     std::thread::sleep(std::time::Duration::from_secs(1));

--- a/elkodon/src/port/publisher.rs
+++ b/elkodon/src/port/publisher.rs
@@ -18,6 +18,7 @@
 //!     .create()?;
 //!
 //! // loan some initialized memory and send it
+//! // the message type must implement the [`core::default::Default`] trait in order to be able to use this API
 //! let mut sample = publisher.loan()?;
 //! *sample.payload_mut() = 1337;
 //! publisher.send(sample)?;
@@ -27,7 +28,7 @@
 //! let sample = sample.write_payload(1337);
 //! publisher.send(sample)?;
 //!
-//! // loan some uninitialized memory and send it (with accessing `MaybeUninit<MessageType>`
+//! // loan some uninitialized memory and send it (with direct access of [`core::mem::MaybeUninit<MessageType>`])
 //! let mut sample = publisher.loan_uninit()?;
 //! sample.payload_mut().write(1337);
 //! let sample = unsafe { sample.assume_init() };
@@ -545,7 +546,7 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Debug>
     /// # let publisher = service.publisher().create()?;
     ///
     /// let sample = publisher.loan_uninit()?;
-    /// let sample = sample.write_payload(42); // alternatively `sample.payload_mut()` can be use to access the `MaybeUninit<MessageType>
+    /// let sample = sample.write_payload(42); // alternatively `sample.payload_mut()` can be use to access the `MaybeUninit<MessageType>`
     ///
     /// publisher.send(sample)?;
     ///
@@ -616,7 +617,7 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Default +
 {
     /// Loans/allocates a [`SampleMut`] from the underlying data segment of the [`Publisher`]
     /// and initialize it with the default value. This can be a performance hit and [`Publisher::loan_uninit`]
-    /// can be used to loan a `MaybeUninit<MessageType>`.
+    /// can be used to loan a [`core::mem::MaybeUninit<MessageType>`].
     ///
     /// On failure it returns [`LoanError`] describing the failure.
     ///

--- a/elkodon/src/port/publisher.rs
+++ b/elkodon/src/port/publisher.rs
@@ -576,3 +576,15 @@ impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Debug>
         }
     }
 }
+
+impl<'a, 'config: 'a, Service: service::Details<'config>, MessageType: Default + Debug>
+    Publisher<'a, 'config, Service, MessageType>
+{
+    /// Loans/allocates a [`SampleMut`] from the underlying data segment of the [`Publisher`].
+    /// On failure it returns [`LoanError`] describing the failure.
+    pub fn loan<'publisher>(
+        &'publisher self,
+    ) -> Result<SampleMut<'a, 'publisher, 'config, Service, Header, MessageType>, LoanError> {
+        Ok(self.loan_uninit()?.write_payload(MessageType::default()))
+    }
+}

--- a/elkodon/src/sample_mut.rs
+++ b/elkodon/src/sample_mut.rs
@@ -11,9 +11,8 @@
 //! #
 //! # let publisher = service.publisher().create()?;
 //!
-//! let mut sample = publisher.loan_uninit()?;
-//! sample.payload_mut().write(1234);
-//! let sample = unsafe { sample.assume_init() };
+//! let sample = publisher.loan_uninit()?;
+//! let sample = sample.write_payload(1234);
 //!
 //! println!("timestamp: {:?}, publisher port id: {:?}",
 //!     sample.header().time_stamp(), sample.header().publisher_id());
@@ -102,7 +101,7 @@ impl<
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
-    /// let mut sample = publisher.loan_uninit()?;
+    /// let sample = publisher.loan_uninit()?;
     /// let sample = sample.write_payload(1234);
     ///
     /// publisher.send(sample)?;

--- a/elkodon/src/sample_mut.rs
+++ b/elkodon/src/sample_mut.rs
@@ -35,7 +35,7 @@ use std::{fmt::Debug, mem::MaybeUninit, sync::atomic::Ordering};
 /// Does not implement [`Send`] since it releases unsent samples in the [`Publisher`] and the
 /// [`Publisher`] is not thread-safe!
 ///
-/// The generic parameter `M` is either a `MessageType` or a `MaybeUninit<MessageType>`, depending
+/// The generic parameter `M` is either a `MessageType` or a [`core::mem::MaybeUninit<MessageType>`], depending
 /// which API is used to obtain the sample.
 #[derive(Debug)]
 pub struct SampleMut<
@@ -118,11 +118,11 @@ impl<
         unsafe { self.assume_init() }
     }
 
-    /// Extracts the value of the `MaybeUninit<MessageType>` container and labels the sample as initialized
+    /// Extracts the value of the [`core::mem::MaybeUninit<MessageType>`] container and labels the sample as initialized
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `MaybeUninit<MessageType>` really is initialized. Calling this when
+    /// The caller must ensure that [`core::mem::MaybeUninit<MessageType>`] really is initialized. Calling this when
     /// the content is not fully initialized causes immediate undefined behavior.
     ///
     /// # Example
@@ -178,7 +178,7 @@ impl<
     ///
     /// # Notes
     ///
-    /// The generic parameter `M` is either a `MessageType` or a `MaybeUninit<MessageType>`, depending
+    /// The generic parameter `M` is either a `MessageType` or a [`core::mem::MaybeUninit<MessageType>`], depending
     /// which API is used to obtain the sample. Obtaining a reference is safe for either type.
     pub fn payload(&self) -> &M {
         self.ptr.as_data_ref()
@@ -188,7 +188,7 @@ impl<
     ///
     /// # Notes
     ///
-    /// The generic parameter `M` is either a `MessageType` or a `MaybeUninit<MessageType>`, depending
+    /// The generic parameter `M` is either a `MessageType` or a [`core::mem::MaybeUninit<MessageType>`], depending
     /// which API is used to obtain the sample. Obtaining a mut reference is safe for either type.
     pub fn payload_mut(&mut self) -> &mut M {
         self.ptr.as_data_mut()

--- a/elkodon/src/sample_mut.rs
+++ b/elkodon/src/sample_mut.rs
@@ -11,7 +11,7 @@
 //! #
 //! # let publisher = service.publisher().create()?;
 //!
-//! let mut sample = publisher.loan()?;
+//! let mut sample = publisher.loan_uninit()?;
 //! sample.payload_mut().write(1234);
 //! let sample = unsafe { sample.assume_init() };
 //!
@@ -27,7 +27,7 @@ use crate::{port::publisher::Publisher, raw_sample::RawSampleMut, service};
 use elkodon_cal::shared_memory::*;
 use std::{fmt::Debug, mem::MaybeUninit, sync::atomic::Ordering};
 
-/// Acquired by a [`Publisher`] via [`Publisher::loan()`]. It stores the payload that will be sent
+/// Acquired by a [`Publisher`] via [`Publisher::loan()`] or [`Publisher::loan_uninit()`]. It stores the payload that will be sent
 /// to all connected [`crate::port::subscriber::Subscriber`]s. If the [`SampleMut`] is not sent
 /// it will release the loaned memory when going out of scope.
 ///
@@ -102,7 +102,7 @@ impl<
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
-    /// let mut sample = publisher.loan()?;
+    /// let mut sample = publisher.loan_uninit()?;
     /// let sample = sample.write_payload(1234);
     ///
     /// publisher.send(sample)?;
@@ -139,7 +139,7 @@ impl<
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
-    /// let mut sample = publisher.loan()?;
+    /// let mut sample = publisher.loan_uninit()?;
     /// sample.payload_mut().write(1234);
     /// let sample = unsafe { sample.assume_init() };
     ///

--- a/elkodon/src/service/port_factory/publisher.rs
+++ b/elkodon/src/service/port_factory/publisher.rs
@@ -130,7 +130,7 @@ impl<'factory, 'config, Service: service::Details<'config>, MessageType: Debug>
     }
 
     /// Defines how many [`crate::sample_mut::SampleMut`] the [`Publisher`] can loan with
-    /// [`Publisher::loan()`] in parallel.
+    /// [`Publisher::loan()`] or [`Publisher::loan_uninit()`] in parallel.
     pub fn max_loaned_samples(mut self, value: usize) -> Self {
         self.config.max_loaned_samples = value;
         self

--- a/elkodon/tests/publisher_tests.rs
+++ b/elkodon/tests/publisher_tests.rs
@@ -36,9 +36,9 @@ mod publisher {
 
         let sut = service.publisher().max_loaned_samples(4).create().unwrap();
 
-        let mut sample1 = sut.loan().unwrap();
-        let mut sample2 = sut.loan().unwrap();
-        let mut sample3 = sut.loan().unwrap();
+        let mut sample1 = sut.loan_uninit().unwrap();
+        let mut sample2 = sut.loan_uninit().unwrap();
+        let mut sample3 = sut.loan_uninit().unwrap();
 
         sample1.payload_mut().write(1);
         sample2.payload_mut().write(2);
@@ -70,10 +70,10 @@ mod publisher {
 
         let sut = service.publisher().max_loaned_samples(2).create().unwrap();
 
-        let _sample1 = sut.loan().unwrap();
-        let _sample2 = sut.loan().unwrap();
+        let _sample1 = sut.loan_uninit().unwrap();
+        let _sample2 = sut.loan_uninit().unwrap();
 
-        let sample3 = sut.loan();
+        let sample3 = sut.loan_uninit();
         assert_that!(sample3, is_err);
         assert_that!(sample3.err().unwrap(), eq LoanError::ExceedsMaxLoanedChunks);
     }
@@ -88,15 +88,15 @@ mod publisher {
 
         let sut = service.publisher().max_loaned_samples(2).create().unwrap();
 
-        let _sample1 = sut.loan().unwrap();
-        let mut sample2 = sut.loan().unwrap();
+        let _sample1 = sut.loan_uninit().unwrap();
+        let mut sample2 = sut.loan_uninit().unwrap();
         sample2.payload_mut().write(2);
         let sample2 = unsafe { sample2.assume_init() };
 
         assert_that!(sut.send(sample2), is_ok);
 
-        let _sample3 = sut.loan();
-        let sample4 = sut.loan();
+        let _sample3 = sut.loan_uninit();
+        let sample4 = sut.loan_uninit();
         assert_that!(sample4, is_err);
         assert_that!(sample4.err().unwrap(), eq LoanError::ExceedsMaxLoanedChunks);
     }
@@ -111,13 +111,13 @@ mod publisher {
 
         let sut = service.publisher().max_loaned_samples(2).create().unwrap();
 
-        let _sample1 = sut.loan().unwrap();
-        let sample2 = sut.loan().unwrap();
+        let _sample1 = sut.loan_uninit().unwrap();
+        let sample2 = sut.loan_uninit().unwrap();
 
         drop(sample2);
 
-        let _sample3 = sut.loan();
-        let sample4 = sut.loan();
+        let _sample3 = sut.loan_uninit();
+        let sample4 = sut.loan_uninit();
         assert_that!(sample4, is_err);
         assert_that!(sample4.err().unwrap(), eq LoanError::ExceedsMaxLoanedChunks);
     }

--- a/elkodon/tests/publisher_tests.rs
+++ b/elkodon/tests/publisher_tests.rs
@@ -36,14 +36,9 @@ mod publisher {
 
         let sut = service.publisher().max_loaned_samples(4).create().unwrap();
 
-        let mut sample1 = sut.loan_uninit().unwrap();
-        let mut sample2 = sut.loan_uninit().unwrap();
-        let mut sample3 = sut.loan_uninit().unwrap();
-
-        sample1.payload_mut().write(1);
-        sample2.payload_mut().write(2);
-        sample3.payload_mut().write(3);
-        let sample3 = unsafe { sample3.assume_init() };
+        let sample1 = sut.loan_uninit().unwrap().write_payload(1);
+        let sample2 = sut.loan_uninit().unwrap().write_payload(2);
+        let sample3 = sut.loan_uninit().unwrap().write_payload(3);
 
         let subscriber = service.subscriber().create().unwrap();
 
@@ -89,9 +84,7 @@ mod publisher {
         let sut = service.publisher().max_loaned_samples(2).create().unwrap();
 
         let _sample1 = sut.loan_uninit().unwrap();
-        let mut sample2 = sut.loan_uninit().unwrap();
-        sample2.payload_mut().write(2);
-        let sample2 = unsafe { sample2.assume_init() };
+        let sample2 = sut.loan_uninit().unwrap().write_payload(2);
 
         assert_that!(sut.send(sample2), is_ok);
 

--- a/elkodon/tests/service_publish_subscribe_tests.rs
+++ b/elkodon/tests/service_publish_subscribe_tests.rs
@@ -819,12 +819,12 @@ mod service_publish_subscribe {
             // max out loan
             let mut loaned_samples = vec![];
             for _ in 0..max_loan {
-                let sample = sut_publisher.loan();
+                let sample = sut_publisher.loan_uninit();
                 assert_that!(sample, is_ok);
                 loaned_samples.push(sample);
             }
 
-            let sample = sut_publisher.loan();
+            let sample = sut_publisher.loan_uninit();
             assert_that!(sample, is_err);
             assert_that!(sample.err().unwrap(), eq LoanError::ExceedsMaxLoanedChunks);
 

--- a/examples/examples/publish_subscribe/publisher.rs
+++ b/examples/examples/publish_subscribe/publisher.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while !SignalHandler::termination_requested() {
         counter += 1;
 
-        let mut sample = publisher.loan()?;
+        let mut sample = publisher.loan_uninit()?;
 
         sample.payload_mut().write(TransmissionData {
             x: counter as i32,

--- a/examples/examples/publish_subscribe/publisher.rs
+++ b/examples/examples/publish_subscribe/publisher.rs
@@ -16,15 +16,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while !SignalHandler::termination_requested() {
         counter += 1;
 
-        let mut sample = publisher.loan_uninit()?;
+        let sample = publisher.loan_uninit()?;
 
-        sample.payload_mut().write(TransmissionData {
+        let sample = sample.write_payload(TransmissionData {
             x: counter as i32,
             y: counter as i32 * 3,
             funky: counter as f64 * 812.12,
         });
 
-        let sample = unsafe { sample.assume_init() };
         publisher.send(sample)?;
 
         println!("Send sample {} ...", counter);


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR renames `loan` to `loan_uninit` and introduces a `loan` method with `Default` trait bounds.

The documentation is updated to use `write_payload` where appropriate which make it possible to use elkodon zero-copy API without unsafe.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked
1. [x] Every source code file has the SPDX header `SPDX-License-Identifier: $(LICENSE_CODE)`
1. [x] Branch follows the naming format (`elk-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/larry-robotics/elkodon/blob/main/doc/release-notes/elkodon-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue.

Closes #47
